### PR TITLE
Include props as second argument in callback param to createCustomTypeChecker

### DIFF
--- a/lib/custom-proptypes.js
+++ b/lib/custom-proptypes.js
@@ -52,7 +52,9 @@ function createCustomTypeChecker(
   ) {
     const prop = props[propName];
 
-    if (typeof callback(prop) !== 'boolean') {
+    const success = callback(prop);
+
+    if (typeof success !== 'boolean') {
       return new Error(
         'Invalid createPropType input: callback parameter must evaluate to a boolean value. ' +
         'See https://github.com/jackrzhang/react-custom-proptypes#parameters for details.'
@@ -69,7 +71,7 @@ function createCustomTypeChecker(
     message = message || `Invalid prop \`${propName}\` supplied to \`${componentName}\`. Validation failed.`;
     /* eslint-enable no-param-reassign, max-len */
 
-    if (!callback(prop)) {
+    if (!success) {
       return new Error(message);
     }
 
@@ -90,7 +92,9 @@ function createCustomIteratorTypeChecker(
 ) {
     const prop = propValue[key];
 
-    if (typeof callback(prop) !== 'boolean') {
+    const success = callback(prop, key);
+
+    if (typeof success !== 'boolean') {
       return new Error(
         'Invalid createIteratorPropType input: ' +
         'callback parameter must evaluate to a boolean value. ' +
@@ -109,7 +113,7 @@ function createCustomIteratorTypeChecker(
     message = message || `Invalid prop \`${propFullName}\` supplied to \`${componentName}\`. Validation failed.`;
     /* eslint-enable no-param-reassign, max-len */
 
-    if (!callback(prop, key)) {
+    if (!success) {
       return new Error(message);
     }
 

--- a/lib/custom-proptypes.js
+++ b/lib/custom-proptypes.js
@@ -52,7 +52,7 @@ function createCustomTypeChecker(
   ) {
     const prop = props[propName];
 
-    const success = callback(prop);
+    const success = callback(prop, props);
 
     if (typeof success !== 'boolean') {
       return new Error(


### PR DESCRIPTION
This allows the evaluating callback function to use multiple prop values together as the basis for the evaluation.
